### PR TITLE
Renaming package from `expo-auth-session-et` to `expo-auth-session`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "expo-auth-session-et",
+  "name": "expo-auth-session",
   "version": "1.2.0-et",
   "description": "Expo module for browser-based authentication",
   "main": "build/AuthSession.js",


### PR DESCRIPTION
Renaming package from `expo-auth-session-et` to `expo-auth-session` to allow us to add the package with the same name as the original. This will allow us to swap our package with the original if needed without having to change the code.